### PR TITLE
Ensure Buffer conforms to Writer interface

### DIFF
--- a/bufit.go
+++ b/bufit.go
@@ -145,6 +145,18 @@ func (b *Buffer) Close() error {
 	return nil
 }
 
+// Len returns the #  of bytes buffered for Readers
+func (b *Buffer) Len() int {
+	return b.buf.Len()
+}
+
+// Discard drops the next n buffered bytes. It returns the actual number of
+// bytes dropped and may return io.EOF if all remaining bytes have been
+// discarded.
+func (b *Buffer) Discard(n int) (int, error) {
+	return b.buf.Discard(n)
+}
+
 // NewBuffer creates and returns a new Buffer backed by the passed Writer
 func NewBuffer(w Writer) *Buffer {
 	buf := Buffer{

--- a/bufit_test.go
+++ b/bufit_test.go
@@ -92,6 +92,25 @@ func BenchmarkReadWriter(b *testing.B) {
 	b.ReportAllocs()
 }
 
+func TestAsWriter(t *testing.T) {
+	buf := New()
+	if n := buf.Len(); n != 0 {
+		t.Errorf("Len() returned unexpected %d", n)
+	}
+
+	io.WriteString(buf, "hello world")
+	if n := buf.Len(); n != 11 {
+		t.Errorf("Len() returned unexpected %d", n)
+	}
+
+	if n, err := buf.Discard(6); n != 6 {
+		t.Errorf("Discard(6) returned unexpected %d, %v", n, err)
+	}
+	if n := buf.Len(); n != 5 {
+		t.Errorf("Len() returned unexpected %d", n)
+	}
+}
+
 func TestConcurrent(t *testing.T) {
 	var grp sync.WaitGroup
 	buf := New()


### PR DESCRIPTION
This exposes `Len()` and `Discard()` on `Buffer`, which makes it possible for users to query and limit the size of the underlying buffer.